### PR TITLE
Support encoding/gob serialization

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -57,6 +57,7 @@ that estimating the FP rate will clear the Bloom filter.
 package bloom
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/json"
 	"github.com/willf/bitset"
@@ -254,4 +255,22 @@ func (f *BloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 	f.b = b
 	f.hasher = fnv.New64()
 	return numBytes + int64(2*binary.Size(uint64(0))), nil
+}
+
+// GobEncode implements gob.GobEncoder interface.
+func (f *BloomFilter) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := f.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// GobDecode implements gob.GobDecoder interface.
+func (f *BloomFilter) GobDecode(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	_, err := f.ReadFrom(buf)
+	return err
 }

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -3,6 +3,7 @@ package bloom
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -162,6 +163,45 @@ func TestReadWriteBinary(t *testing.T) {
 	}
 	if !g.b.Equal(f.b) {
 		t.Error("bitsets are not equal")
+	}
+}
+
+func TestEncodeDecodeGob(t *testing.T) {
+	f := New(1000, 4)
+	f.Add([]byte("one"))
+	f.Add([]byte("two"))
+	f.Add([]byte("three"))
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(f)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var g BloomFilter
+	err = gob.NewDecoder(&buf).Decode(&g)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if g.m != f.m {
+		t.Error("invalid m value")
+	}
+	if g.k != f.k {
+		t.Error("invalid k value")
+	}
+	if g.b == nil {
+		t.Fatal("bitset is nil")
+	}
+	if !g.b.Equal(f.b) {
+		t.Error("bitsets are not equal")
+	}
+	if !g.Test([]byte("three")) {
+		t.Errorf("missing value 'three'")
+	}
+	if !g.Test([]byte("two")) {
+		t.Errorf("missing value 'two'")
+	}
+	if !g.Test([]byte("one")) {
+		t.Errorf("missing value 'one'")
 	}
 }
 


### PR DESCRIPTION
By implementing the GobEncoder and GobDecoder interfaces, the package
encoding/gob can serialize and deserialize bloom filters.  This allows
other packages (like appengine/delay) to pass them conveniently between
servers.
