### PR TITLE
Used a []uint as buffer to reduce memallocs.

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -279,5 +279,6 @@ func (f *BloomFilter) GobEncode() ([]byte, error) {
 func (f *BloomFilter) GobDecode(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	_, err := f.ReadFrom(buf)
+	f.locBuff = make([]uint, f.k)
 	return err
 }

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -3,7 +3,9 @@ package bloom
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/gob"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -164,26 +166,76 @@ func TestReadWriteBinary(t *testing.T) {
 	}
 }
 
+func TestEncodeDecodeGob(t *testing.T) {
+	f := New(1000, 4)
+	f.Add([]byte("one"))
+	f.Add([]byte("two"))
+	f.Add([]byte("three"))
+	var buf bytes.Buffer
+	err := gob.NewEncoder(&buf).Encode(f)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	var g BloomFilter
+	err = gob.NewDecoder(&buf).Decode(&g)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if g.m != f.m {
+		t.Error("invalid m value")
+	}
+	if g.k != f.k {
+		t.Error("invalid k value")
+	}
+	if g.b == nil {
+		t.Fatal("bitset is nil")
+	}
+	if !g.b.Equal(f.b) {
+		t.Error("bitsets are not equal")
+	}
+	if !g.Test([]byte("three")) {
+		t.Errorf("missing value 'three'")
+	}
+	if !g.Test([]byte("two")) {
+		t.Errorf("missing value 'two'")
+	}
+	if !g.Test([]byte("one")) {
+		t.Errorf("missing value 'one'")
+	}
+}
+
 func BenchmarkDirect(b *testing.B) {
 	n := uint(10000)
 	max_k := uint(10)
 	max_load := uint(20)
-
+	fmt.Printf("m/n")
+	for k := uint(2); k <= max_k; k++ {
+		fmt.Printf("\tk=%v", k)
+	}
+	fmt.Println()
 	for load := uint(2); load <= max_load; load++ {
+		fmt.Print(load)
 		for k := uint(2); k <= max_k; k++ {
 			f := New(n*load, k)
-			f.EstimateFalsePositiveRate(n)
+			fp_rate := f.EstimateFalsePositiveRate(n)
+			fmt.Printf("\t%f", fp_rate)
 		}
+		fmt.Println()
 	}
 }
 
 func BenchmarkEstimted(b *testing.B) {
 	for n := uint(5000); n <= 50000; n += 5000 {
+		fmt.Printf("%v", n)
 		for fp := 0.1; fp >= 0.00001; fp /= 10.0 {
-			estimateParameters(n, fp)
+			fmt.Printf("\t%f", fp)
+			m, k := estimateParameters(n, fp)
 			f := NewWithEstimates(n, fp)
-			f.EstimateFalsePositiveRate(n)
+			fp_rate := f.EstimateFalsePositiveRate(n)
+			fmt.Printf("\t%v\t%v\t%f", m, k, fp_rate)
 		}
+		fmt.Println()
 	}
 }
 


### PR DESCRIPTION
Because this is a performance critical part of an application I am writing, I figured I would pull request my optimizations. 

I used a []uint buffer that is stored in the filter that way one doesn't have to be created for every request.
