### PR TITLE
optimize bloom filter implementation

### DIFF
--- a/bloom_test.go
+++ b/bloom_test.go
@@ -199,7 +199,7 @@ func chiTestBloom(m, k, rounds uint, elements [][]byte) (succeeds bool) {
 	chi := make([]float64, m)
 
 	for _, data := range elements {
-		h := baseHashes(data)
+		h := f.baseHashes(data)
 		for i := uint(0); i < f.k; i++ {
 			results[f.location(h, i)]++
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/segmentio/bloom
+
+go 1.13
+
+require (
+	github.com/spaolacci/murmur3 v1.1.0
+	github.com/willf/bitset v1.1.10
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/willf/bitset v1.1.10 h1:NotGKqX0KwQ72NUzqrjZq5ipPNDQex9lo3WpaS8L2sc=
+github.com/willf/bitset v1.1.10/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=


### PR DESCRIPTION
Hello, and thanks for this package!

This PR modifies the bloom filter implementation to avoid recreating the hasher for every operation, which was the only cause of heap allocations in this code. I believe this is OK since the documentation states that the BloomFilter type isn't safe to use concurrently from multiple goroutines.

Here are results from the benchmarks in this package before and after the change:
```
$ benchcmp /tmp/bench{1,2}
benchmark                       old ns/op     new ns/op     delta
BenchmarkEstimated              0.12          0.08          -29.74%
BenchmarkSeparateTestAndAdd     410           395           -3.66%
BenchmarkCombinedTestAndAdd     385           349           -9.35%

benchmark                       old allocs     new allocs     delta
BenchmarkEstimated              0              0              +0.00%
BenchmarkSeparateTestAndAdd     4              0              -100.00%
BenchmarkCombinedTestAndAdd     2              0              -100.00%

benchmark                       old bytes     new bytes     delta
BenchmarkEstimated              0             0             +0.00%
BenchmarkSeparateTestAndAdd     194           0             -100.00%
BenchmarkCombinedTestAndAdd     97            0             -100.00%
```

Let me know if you have any concerns about merging this change!