### PR TITLE
Heap-free hashing

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -56,7 +56,6 @@ import (
 	"io"
 	"math"
 
-	"github.com/spaolacci/murmur3"
 	"github.com/willf/bitset"
 )
 
@@ -92,14 +91,10 @@ func From(data []uint64, k uint) *BloomFilter {
 // baseHashes returns the four hash values of data that are used to create k
 // hashes
 func baseHashes(data []byte) [4]uint64 {
-	a1 := []byte{1} // to grab another bit of data
-	hasher := murmur3.New128()
-	hasher.Write(data) // #nosec
-	v1, v2 := hasher.Sum128()
-	hasher.Write(a1) // #nosec
-	v3, v4 := hasher.Sum128()
+	var d digest128;
+	hash1, hash2, hash3, hash4 := d.sum256(data)
 	return [4]uint64{
-		v1, v2, v3, v4,
+		hash1, hash2, hash3, hash4,
 	}
 }
 

--- a/bloom.go
+++ b/bloom.go
@@ -91,7 +91,7 @@ func From(data []uint64, k uint) *BloomFilter {
 // baseHashes returns the four hash values of data that are used to create k
 // hashes
 func baseHashes(data []byte) [4]uint64 {
-	var d digest128;
+	var d digest128 // murmur hashing
 	hash1, hash2, hash3, hash4 := d.sum256(data)
 	return [4]uint64{
 		hash1, hash2, hash3, hash4,

--- a/murmur.go
+++ b/murmur.go
@@ -1,0 +1,264 @@
+/*
+The bloom library relied on the excellent murmur library
+by Sébastien Paolacci. Unfortunately, it involved some heap
+allocation. We want to avoid any heap allocation whatsoever
+in the hashing process. To preserve backward compatibility, we roll
+our own version.
+
+License on original code:
+
+
+Copyright 2013, Sébastien Paolacci.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the library nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+package bloom
+
+import (
+	"math/bits"
+	"unsafe"
+)
+
+const (
+	c1_128     = 0x87c37b91114253d5
+	c2_128     = 0x4cf5ad432745937f
+	block_size = 16
+)
+
+// digest128 represents a partial evaluation of a 128 bites hash.
+type digest128 struct {
+	h1 uint64 // Unfinalized running hash part 1.
+	h2 uint64 // Unfinalized running hash part 2.
+}
+
+func (d *digest128) bmix(p []byte) {
+	nblocks := len(p) / block_size
+	for i := 0; i < nblocks; i++ {
+		t := (*[2]uint64)(unsafe.Pointer(&p[i*block_size]))
+		k1, k2 := t[0], t[1]
+		d.bmix_words(k1, k2)
+	}
+}
+
+func (d *digest128) bmix_words(k1, k2 uint64) {
+	h1, h2 := d.h1, d.h2
+
+	k1 *= c1_128
+	k1 = bits.RotateLeft64(k1, 31)
+	k1 *= c2_128
+	h1 ^= k1
+
+	h1 = bits.RotateLeft64(h1, 27)
+	h1 += h2
+	h1 = h1*5 + 0x52dce729
+
+	k2 *= c2_128
+	k2 = bits.RotateLeft64(k2, 33)
+	k2 *= c1_128
+	h2 ^= k2
+
+	h2 = bits.RotateLeft64(h2, 31)
+	h2 += h1
+	h2 = h2*5 + 0x38495ab5
+	d.h1, d.h2 = h1, h2
+}
+
+func (d *digest128) sum128(pad_tail bool, length uint, tail []byte) (h1, h2 uint64) {
+	h1, h2 = d.h1, d.h2
+
+	var k1, k2 uint64
+	if pad_tail {
+		switch (len(tail) + 1) & 15 {
+		case 15:
+			k2 ^= uint64(1) << 48
+			break
+		case 14:
+			k2 ^= uint64(1) << 40
+			break
+		case 13:
+			k2 ^= uint64(1) << 32
+			break
+		case 12:
+			k2 ^= uint64(1) << 24
+			break
+		case 11:
+			k2 ^= uint64(1) << 16
+			break
+		case 10:
+			k2 ^= uint64(1) << 8
+			break
+		case 9:
+			k2 ^= uint64(1) << 0
+
+			k2 *= c2_128
+			k2 = bits.RotateLeft64(k2, 33)
+			k2 *= c1_128
+			h2 ^= k2
+
+			break
+
+		case 8:
+			k1 ^= uint64(1) << 56
+			break
+		case 7:
+			k1 ^= uint64(1) << 48
+			break
+		case 6:
+			k1 ^= uint64(1) << 40
+			break
+		case 5:
+			k1 ^= uint64(1) << 32
+			break
+		case 4:
+			k1 ^= uint64(1) << 24
+			break
+		case 3:
+			k1 ^= uint64(1) << 16
+			break
+		case 2:
+			k1 ^= uint64(1) << 8
+			break
+		case 1:
+			k1 ^= uint64(1) << 0
+			k1 *= c1_128
+			k1 = bits.RotateLeft64(k1, 31)
+			k1 *= c2_128
+			h1 ^= k1
+		}
+
+	}
+	switch len(tail) & 15 {
+	case 15:
+		k2 ^= uint64(tail[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(tail[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(tail[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(tail[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(tail[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(tail[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(tail[8]) << 0
+
+		k2 *= c2_128
+		k2 = bits.RotateLeft64(k2, 33)
+		k2 *= c1_128
+		h2 ^= k2
+
+		fallthrough
+
+	case 8:
+		k1 ^= uint64(tail[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(tail[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(tail[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(tail[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(tail[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(tail[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(tail[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(tail[0]) << 0
+		k1 *= c1_128
+		k1 = bits.RotateLeft64(k1, 31)
+		k1 *= c2_128
+		h1 ^= k1
+	}
+
+	h1 ^= uint64(length)
+	h2 ^= uint64(length)
+
+	h1 += h2
+	h2 += h1
+
+	h1 = fmix64(h1)
+	h2 = fmix64(h2)
+
+	h1 += h2
+	h2 += h1
+
+	return h1, h2
+}
+
+func fmix64(k uint64) uint64 {
+	k ^= k >> 33
+	k *= 0xff51afd7ed558ccd
+	k ^= k >> 33
+	k *= 0xc4ceb9fe1a85ec53
+	k ^= k >> 33
+	return k
+}
+
+func (d *digest128) sum256(data []byte) (hash1, hash2, hash3, hash4 uint64) {
+	// We always start from zero.
+	d.h1, d.h2 = 0, 0
+	// Process as many bytes as possible.
+	d.bmix(data)
+	// We have enough to compute the first two 64-bit numbers
+	length := uint(len(data))
+
+	tail_length := length % block_size
+
+	tail := data[length-tail_length:]
+	hash1, hash2 = d.sum128(false, length, tail)
+	// Next we want to 'virtually' append 1 to the input, but,
+	// we do not want to append to an actual array!!!
+	if tail_length+1 == block_size {
+		// We are left with no tail!!!
+		// We assume little endian encoding
+		word1 := *(*uint64)(unsafe.Pointer(&tail[0]))
+		word2 := uint64(*(*uint32)(unsafe.Pointer(&tail[8])))
+		word2 = word2 | (uint64(tail[12]) << 32) | (uint64(tail[13]) << 40) | (uint64(tail[14]) << 48)
+		word2 = word2 | (uint64(1) << 56)
+		d.bmix_words(word1, word2)
+		tail := data[length:] // empty slice
+		hash3, hash4 = d.sum128(false, length+1, tail)
+	} else {
+		hash3, hash4 = d.sum128(true, length+1, tail)
+	}
+
+	return hash1, hash2, hash3, hash4
+}

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,0 +1,55 @@
+package bloom
+
+import (
+	"github.com/spaolacci/murmur3"
+	"math/rand"
+	"testing"
+)
+
+// We want to preserve backward compatibility
+func TestHashBasic(t *testing.T) {
+	max_length := 1000
+	bigdata := make([]byte, max_length)
+	for i := 0; i < max_length; i++ {
+		bigdata[i] = byte(i)
+	}
+	for length := 0; length <= 1000; length++ {
+		data := bigdata[:length]
+		var d digest128
+		h1, h2, h3, h4 := d.sum256(data)
+		//
+		a1 := []byte{1} // to grab another bit of data
+		hasher := murmur3.New128()
+		hasher.Write(data) // #nosec
+		v1, v2 := hasher.Sum128()
+		hasher.Write(a1) // #nosec
+		v3, v4 := hasher.Sum128()
+		if v1 != h1 || v2 != h2 || v3 != h3 || v4 != h4 {
+			t.Errorf("Backward compatibillity break.")
+		}
+	}
+}
+
+// We want to preserve backward compatibility
+func TestHashRandom(t *testing.T) {
+	max_length := 1000
+	bigdata := make([]byte, max_length)
+	for length := 0; length <= 1000; length++ {
+		data := bigdata[:length]
+		for trial := 1; trial < 10; trial++ {
+			rand.Read(data)
+			var d digest128
+			h1, h2, h3, h4 := d.sum256(data)
+			//
+			a1 := []byte{1} // to grab another bit of data
+			hasher := murmur3.New128()
+			hasher.Write(data) // #nosec
+			v1, v2 := hasher.Sum128()
+			hasher.Write(a1) // #nosec
+			v3, v4 := hasher.Sum128()
+			if v1 != h1 || v2 != h2 || v3 != h3 || v4 != h4 {
+				t.Errorf("Backward compatibillity break.")
+			}
+		}
+	}
+}


### PR DESCRIPTION
There is no good reason why hashing a block of data should require heap allocation or even a non-trivial dynamic buffer.

Unfortunately, the murmur library makes this a bit difficult. Thankfully, we can just roll our own thin functions. It is possible to do while preserving exactly the same hash values. That's what this PR does.

The goal of this PR is not to improve speed. Of course, it does so... On my machine...

Before:
```
BenchmarkEstimated
BenchmarkEstimated-8                    1000000000               0.1333 ns/op          0 B/op          0 allocs/op
BenchmarkSeparateTestAndAdd
BenchmarkSeparateTestAndAdd-8            2706183               508.2 ns/op           194 B/op          4 allocs/op
BenchmarkCombinedTestAndAdd
BenchmarkCombinedTestAndAdd-8            3312842               437.6 ns/op            97 B/op          2 allocs/op
PASS
```

After...

```
BenchmarkEstimated-8                    1000000000               0.05285 ns/op         0 B/op          0 allocs/op
BenchmarkSeparateTestAndAdd
BenchmarkSeparateTestAndAdd-8            6219651               451.9 ns/op             0 B/op          0 allocs/op
BenchmarkCombinedTestAndAdd
BenchmarkCombinedTestAndAdd-8            5010103               393.2 ns/op             0 B/op          0 allocs/op
PASS
```

So we see about a 10% boost in performance in this instance on my system. Results will vary.

The important part is that it does away entirely with heap allocation.

The PR includes tests to ensure that the hash values are preserved.

Note that if we break backward compatibility (with exact hash value reproduction), there are many great optimization opportunities. But that should be addressed in other PRs.

Related to PRs https://github.com/willf/bloom/pull/51 and https://github.com/willf/bloom/pull/57