### PR TITLE
Fix v3 broken modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: ['1.13', '1.14']
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -13,10 +13,25 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Checkout code
-      uses: actions/checkout@master
-    - name: Get
-      run: go get -d ./...
-    - name: Get murmur
-      run: go get github.com/spaolacci/murmur3
+      uses: actions/checkout@v2
+    - name: Vet
+      run: go vet ./...
     - name: Test
       run: go test ./...
+
+  single-ver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: fmt
+        run: diff <(gofmt -s -d .) <(printf "")
+
+      - name: Test 386
+        run: GOOS=linux GOARCH=386 go test ./...

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 Bloom filters
 -------------
-[![Test](https://github.com/bits-and-blooms/bloom/workflows/Test/badge.svg)](https://github.com/bits-and-blooms/bloom/actions?query=workflow%3ATest)
-[![Coverage Status](https://coveralls.io/repos/github/willf/bloom/badge.svg?branch=master)](https://coveralls.io/github/willf/bloom?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/willf/bloom)](https://goreportcard.com/report/github.com/willf/bloom)
-[![GoDoc](https://godoc.org/github.com/bits-and-blooms/bloom?status.svg)](http://godoc.org/github.com/bits-and-blooms/bloom)
+[![Test](https://github.com/bits-and-blooms/bloom/actions/workflows/test.yml/badge.svg)](https://github.com/bits-and-blooms/bloom/actions/workflows/test.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/bits-and-blooms/bloom)](https://goreportcard.com/report/github.com/bits-and-blooms/bloom)
+[![Go Reference](https://pkg.go.dev/badge/github.com/bits-and-blooms/bloom.svg)](https://pkg.go.dev/github.com/bits-and-blooms/bloom)
 
 A Bloom filter is a concise/compressed representation of a set, where the main
 requirement is to make membership queries; _i.e._, whether an item is a
@@ -50,12 +49,12 @@ For numerical data, we recommend that you look into the encoding/binary library.
 
 Discussion here: [Bloom filter](https://groups.google.com/d/topic/golang-nuts/6MktecKi1bE/discussion)
 
-Godoc documentation: https://godoc.org/github.com/bits-and-blooms/bloom
+Godoc documentation: https://pkg.go.dev/github.com/bits-and-blooms/bloom
 
 ## Installation
 
 ```bash
-go get -u github.com/bits-and-blooms/bloom
+go get -u github.com/bits-and-blooms/bloom/v3
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ go get -u github.com/bits-and-blooms/bloom/v3
 
 If you wish to contribute to this project, please branch and issue a pull request against master ("[GitHub Flow](https://guides.github.com/introduction/flow/)")
 
-This project include a Makefile that allows you to test and build the project with simple commands.
+This project includes a Makefile that allows you to test and build the project with simple commands.
 To see all available options:
 ```bash
 make help
@@ -77,9 +77,9 @@ make qa
 
 ## Design
 
-A Bloom filter has two parameters: _m_, the number of bits used in storage, and _k_, the number of hashing functions on elements of the set. (The actual hashing functions are important, too, but this is not a parameter for this implementation). A Bloom filter is backed by a [BitSet](https://github.com/willf/bitset); a key is represented in the filter by setting the bits at each value of the  hashing functions (modulo _m_). Set membership is done by _testing_ whether the bits at each value of the hashing functions (again, modulo _m_) are set. If so, the item is in the set. If the item is actually in the set, a Bloom filter will never fail (the true positive rate is 1.0); but it is susceptible to false positives. The art is to choose _k_ and _m_ correctly.
+A Bloom filter has two parameters: _m_, the number of bits used in storage, and _k_, the number of hashing functions on elements of the set. (The actual hashing functions are important, too, but this is not a parameter for this implementation). A Bloom filter is backed by a [BitSet](https://github.com/bits-and-blooms/bitset); a key is represented in the filter by setting the bits at each value of the  hashing functions (modulo _m_). Set membership is done by _testing_ whether the bits at each value of the hashing functions (again, modulo _m_) are set. If so, the item is in the set. If the item is actually in the set, a Bloom filter will never fail (the true positive rate is 1.0); but it is susceptible to false positives. The art is to choose _k_ and _m_ correctly.
 
-In this implementation, the hashing functions used is [murmurhash](github.com/spaolacci/murmur3), a non-cryptographic hashing function.
+In this implementation, the hashing functions used is [murmurhash](https://github.com/spaolacci/murmur3), a non-cryptographic hashing function.
 
 
 Given the particular hashing scheme, it's best to be empirical about this. Note

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bits-and-blooms/bloom
+module github.com/bits-and-blooms/bloom/v3
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
+github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -1,9 +1,10 @@
 package bloom
 
 import (
-	"github.com/spaolacci/murmur3"
 	"math/rand"
 	"testing"
+
+	"github.com/spaolacci/murmur3"
 )
 
 // We want to preserve backward compatibility
@@ -31,9 +32,10 @@ func TestHashBasic(t *testing.T) {
 }
 
 func TestDocumentation(t *testing.T) {
-    filter := NewWithEstimates(1000, 0.01)
-	if filter.EstimateFalsePositiveRate(1000) > 0.0101 {
-		t.Errorf("Bad false positive rate")
+	filter := NewWithEstimates(10000, 0.01)
+	got := filter.EstimateFalsePositiveRate(10000)
+	if got > 0.011 || got < 0.009 {
+		t.Errorf("Bad false positive rate %v", got)
 	}
 }
 


### PR DESCRIPTION
* The v3 modules files did not contain the correct path.
* A test was failing. Strange, since it should be deterministic.
* Updated documentation.
* Test on more recent Go versions using modules for dependencies.
* Add go.sum