### PR TITLE
bloom: add func to create bloom with data and m

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -85,6 +85,12 @@ func New(m uint, k uint) *BloomFilter {
 // functions. The data slice is not going to be reset.
 func From(data []uint64, k uint) *BloomFilter {
 	m := uint(len(data) * 64)
+	return FromWithM(data, m, k)
+}
+
+// FromWithM creates a new Bloom filter with _m_ length, _k_ hashing functions.
+// The data slice is not going to be reset.
+func FromWithM(data []uint64, m, k uint) *BloomFilter {
 	return &BloomFilter{m, k, bitset.From(data)}
 }
 


### PR DESCRIPTION
Ordinarily the From function will create a new zeroed data slice.

If we want to create a BloomFilter that is exactly identical to one we had previously, it's not possible.

Add a new function FromWithM which exposes the data slice as an argument so that we can reconstruct a BloomFilter that is identical in every way (data slice, m, k) to a remote BloomFilter.