### PR TITLE
Remove the side effect of the `EstimateFalsePositiveRate` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ _testmain.go
 *.prof
 
 target
+.idea

--- a/bloom.go
+++ b/bloom.go
@@ -222,8 +222,8 @@ func (f *BloomFilter) TestAndAdd(data []byte) bool {
 		l := f.location(h, i)
 		if !f.b.Test(l) {
 			present = false
+			f.b.Set(l)
 		}
-		f.b.Set(l)
 	}
 	return present
 }
@@ -232,27 +232,6 @@ func (f *BloomFilter) TestAndAdd(data []byte) bool {
 // Returns the result of Test.
 func (f *BloomFilter) TestAndAddString(data string) bool {
 	return f.TestAndAdd([]byte(data))
-}
-
-// TestOrAdd is the equivalent to calling Test(data) then if not present Add(data).
-// Returns the result of Test.
-func (f *BloomFilter) TestOrAdd(data []byte) bool {
-	present := true
-	h := baseHashes(data)
-	for i := uint(0); i < f.k; i++ {
-		l := f.location(h, i)
-		if !f.b.Test(l) {
-			present = false
-			f.b.Set(l)
-		}
-	}
-	return present
-}
-
-// TestOrAddString is the equivalent to calling Test(string) then if not present Add(string).
-// Returns the result of Test.
-func (f *BloomFilter) TestOrAddString(data string) bool {
-	return f.TestOrAdd([]byte(data))
 }
 
 // ClearAll clears all the data in a Bloom filter, removing all keys
@@ -264,26 +243,26 @@ func (f *BloomFilter) ClearAll() *BloomFilter {
 // EstimateFalsePositiveRate returns, for a BloomFilter with a estimate of m bits
 // and k hash functions, what the false positive rate will be
 // while storing n entries; runs 100,000 tests. This is an empirical
-// test using integers as keys. As a side-effect, it clears the BloomFilter.
+// test using integers as keys.
 func (f *BloomFilter) EstimateFalsePositiveRate(n uint) (fpRate float64) {
 	rounds := uint32(100000)
-	f.ClearAll()
+	c := f.Copy()
+	c.ClearAll()
 	n1 := make([]byte, 4)
 	for i := uint32(0); i < uint32(n); i++ {
 		binary.BigEndian.PutUint32(n1, i)
-		f.Add(n1)
+		c.Add(n1)
 	}
 	fp := 0
 	// test for number of rounds
 	for i := uint32(0); i < rounds; i++ {
 		binary.BigEndian.PutUint32(n1, i+uint32(n)+1)
-		if f.Test(n1) {
+		if c.Test(n1) {
 			//fmt.Printf("%v failed.\n", i+uint32(n)+1)
 			fp++
 		}
 	}
 	fpRate = float64(fp) / (float64(rounds))
-	f.ClearAll()
 	return
 }
 

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -102,8 +102,6 @@ func TestBasicUint32(t *testing.T) {
 	n1b := f.Test(n1)
 	n2b := f.Test(n2)
 	n3b := f.Test(n3)
-	n5a := f.TestOrAdd(n5)
-	n5b := f.Test(n5)
 	f.Test(n4)
 	if !n1b {
 		t.Errorf("%v should be in.", n1)
@@ -116,12 +114,6 @@ func TestBasicUint32(t *testing.T) {
 	}
 	if !n3b {
 		t.Errorf("%v should be in the second time we look.", n3)
-	}
-	if n5a {
-		t.Errorf("%v should not be in the first time we look.", n5)
-	}
-	if !n5b {
-		t.Errorf("%v should be in the second time we look.", n5)
 	}
 }
 
@@ -141,14 +133,11 @@ func TestString(t *testing.T) {
 	n2 := "is"
 	n3 := "in"
 	n4 := "bloom"
-	n5 := "blooms"
 	f.AddString(n1)
 	n3a := f.TestAndAddString(n3)
 	n1b := f.TestString(n1)
 	n2b := f.TestString(n2)
 	n3b := f.TestString(n3)
-	n5a := f.TestOrAddString(n5)
-	n5b := f.TestString(n5)
 	f.TestString(n4)
 	if !n1b {
 		t.Errorf("%v should be in.", n1)
@@ -162,13 +151,6 @@ func TestString(t *testing.T) {
 	if !n3b {
 		t.Errorf("%v should be in the second time we look.", n3)
 	}
-	if n5a {
-		t.Errorf("%v should not be in the first time we look.", n5)
-	}
-	if !n5b {
-		t.Errorf("%v should be in the second time we look.", n5)
-	}
-
 }
 
 func testEstimated(n uint, maxFp float64, t *testing.T) {


### PR DESCRIPTION
This pull request include three changes.
- Remove the side effect of the `EstimateFalsePositiveRate` function. Using the `Copy` function will has no effect on the current object.
- Remove the repeated `TestOrAdd` function.  For the `TestAndAdd` function, when the `f.b.Test(l)` gets the `true` result, executing the `f.b.Set(l)` and not are same. So only getting `false` to execute `f.b.Set(l)` will decrease one step. Changing it will find the `TestAndAdd` function is same as the `TestOrAdd`.
- Update the `.gitignore` file to filter the `.idea` directory.