### PR TITLE
bloom: Improve the `TestAndAdd` function.

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -222,8 +222,8 @@ func (f *BloomFilter) TestAndAdd(data []byte) bool {
 		l := f.location(h, i)
 		if !f.b.Test(l) {
 			present = false
+			f.b.Set(l)
 		}
-		f.b.Set(l)
 	}
 	return present
 }
@@ -236,23 +236,16 @@ func (f *BloomFilter) TestAndAddString(data string) bool {
 
 // TestOrAdd is the equivalent to calling Test(data) then if not present Add(data).
 // Returns the result of Test.
+// Deprecated: Use TestAndAdd instead.
 func (f *BloomFilter) TestOrAdd(data []byte) bool {
-	present := true
-	h := baseHashes(data)
-	for i := uint(0); i < f.k; i++ {
-		l := f.location(h, i)
-		if !f.b.Test(l) {
-			present = false
-			f.b.Set(l)
-		}
-	}
-	return present
+	return f.TestAndAdd(data)
 }
 
 // TestOrAddString is the equivalent to calling Test(string) then if not present Add(string).
 // Returns the result of Test.
+// Deprecated: Use TestAndAddString instead.
 func (f *BloomFilter) TestOrAddString(data string) bool {
-	return f.TestOrAdd([]byte(data))
+	return f.TestAndAddString(data)
 }
 
 // ClearAll clears all the data in a Bloom filter, removing all keys


### PR DESCRIPTION
For the TestAndAdd function, when the f.b.Test(l) gets the true result, executing the f.b.Set(l) and not are same. So only getting false to execute f.b.Set(l) will decrease one step. Changing it will find the TestAndAdd function is same as the TestOrAdd.