### PR TITLE
New API for EstimateParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ or
 
 You would expect `ActualfpRate` to be close to the desired false-positive rate `fp` in these cases.
 
+The `EstimateFalsePositiveRate` function creates a temporary Bloom filter. It is
+also relatively expensive and only meant for validation.
+
 Discussion here: [Bloom filter](https://groups.google.com/d/topic/golang-nuts/6MktecKi1bE/discussion)
 
 Godoc documentation: https://pkg.go.dev/github.com/bits-and-blooms/bloom

--- a/README.md
+++ b/README.md
@@ -31,13 +31,22 @@ For numeric data, I recommend that you look into the encoding/binary library. Bu
     binary.BigEndian.PutUint32(n1, i)
     filter.Add(n1)
 
-Finally, there is a method to estimate the false positive rate of a particular
-bloom filter for a set of size _n_:
+Finally, there is a method to estimate the false positive rate of a
+Bloom filter with _m_ bits and _k_ hashing functions for a set of size _n_:
 
-    if filter.EstimateFalsePositiveRate(1000) > 0.001
+    if bloom.EstimateFalsePositiveRate(20*n, 5, n) > 0.001 ...
 
-Given the particular hashing scheme, it's best to be empirical about this. Note
-that estimating the FP rate will clear the Bloom filter.
+You can use it to validate the computed m, k parameters:
+
+    m, k := EstimateParameters(n, fp)
+    ActualfpRate := EstimateFalsePositiveRate(m, k, n)
+
+or
+
+	f := NewWithEstimates(n, fp)
+	ActualfpRate := EstimateFalsePositiveRate(f.m, f.k, n)
+
+You would expect ActualfpRate to be close to the desired fp in these cases.
 
 Discussion here: [Bloom filter](https://groups.google.com/d/topic/golang-nuts/6MktecKi1bE/discussion)
 

--- a/bloom.go
+++ b/bloom.go
@@ -45,17 +45,18 @@ Bloom filter with _m_ bits and _k_ hashing functions for a set of size _n_:
 
 You can use it to validate the computed m, k parameters:
 
-    m, k := EstimateParameters(n, fp)
-    ActualfpRate := EstimateFalsePositiveRate(m, k, n)
+    m, k := bloom.EstimateParameters(n, fp)
+    ActualfpRate := bloom.EstimateFalsePositiveRate(m, k, n)
 
 or
 
-	f := NewWithEstimates(n, fp)
-	ActualfpRate := EstimateFalsePositiveRate(f.m, f.k, n)
+	f := bloom.NewWithEstimates(n, fp)
+	ActualfpRate := bloom.EstimateFalsePositiveRate(f.m, f.k, n)
 
 You would expect ActualfpRate to be close to the desired fp in these cases.
 
-The EstimateFalsePositiveRate function creates a temporary Bloom filter.
+The EstimateFalsePositiveRate function creates a temporary Bloom filter. It is
+also relatively expensive and only meant for validation.
 */
 package bloom
 

--- a/bloom.go
+++ b/bloom.go
@@ -281,7 +281,7 @@ func (f *BloomFilter) ClearAll() *BloomFilter {
 func EstimateFalsePositiveRate(m, k, n uint) (fpRate float64) {
 	rounds := uint32(100000)
 	// We construct a new filter.
-	f := New(m,k)
+	f := New(m, k)
 	n1 := make([]byte, 4)
 	// We populate the filter with n values.
 	for i := uint32(0); i < uint32(n); i++ {

--- a/bloom.go
+++ b/bloom.go
@@ -45,8 +45,15 @@ Bloom filter with _m_ bits and _k_ hashing functions for a set of size _n_:
 
 You can use it to validate the computed m, k parameters:
 
-    m, k := EstimateParameters(n, maxFp)
+    m, k := EstimateParameters(n, fp)
     ActualfpRate := EstimateFalsePositiveRate(m, k, n)
+
+or
+
+	f := NewWithEstimates(n, fp)
+	ActualfpRate := EstimateFalsePositiveRate(f.m, f.k, n)
+
+You would expect ActualfpRate to be close to the desired fp in these cases.
 
 The EstimateFalsePositiveRate function creates a temporary Bloom filter.
 */

--- a/bloom.go
+++ b/bloom.go
@@ -38,13 +38,17 @@ for example, to add a uint32 to the filter:
     binary.BigEndian.PutUint32(n1,i)
     f.Add(n1)
 
-Finally, there is a method to estimate the false positive rate of a particular
-Bloom filter for a set of size _n_:
+Finally, there is a method to estimate the false positive rate of a
+Bloom filter with _m_ bits and _k_ hashing functions for a set of size _n_:
 
-    if filter.EstimateFalsePositiveRate(1000) > 0.001
+    if bloom.EstimateFalsePositiveRate(20*n, 5, n) > 0.001 ...
 
-Given the particular hashing scheme, it's best to be empirical about this. Note
-that estimating the FP rate will clear the Bloom filter.
+You can use it to validate the computed m, k parameters:
+
+    m, k := EstimateParameters(n, maxFp)
+    ActualfpRate := EstimateFalsePositiveRate(m, k, n)
+
+The EstimateFalsePositiveRate function creates a temporary Bloom filter.
 */
 package bloom
 
@@ -229,14 +233,17 @@ func (f *BloomFilter) ClearAll() *BloomFilter {
 	return f
 }
 
-// EstimateFalsePositiveRate returns, for a BloomFilter with a estimate of m bits
-// and k hash functions, what the false positive rate will be
-// while storing n entries; runs 100,000 tests. This is an empirical
-// test using integers as keys. As a side-effect, it clears the BloomFilter.
-func (f *BloomFilter) EstimateFalsePositiveRate(n uint) (fpRate float64) {
+// EstimateFalsePositiveRate returns, for a BloomFilter of m bits
+// and k hash functions, an estimation of the false positive rate when
+//  storing n entries. This is an empirical, relatively slow
+// test using integers as keys.
+// This function is useful to validate the implementation.
+func EstimateFalsePositiveRate(m, k, n uint) (fpRate float64) {
 	rounds := uint32(100000)
-	f.ClearAll()
+	// We construct a new filter.
+	f := New(m,k)
 	n1 := make([]byte, 4)
+	// We populate the filter with n values.
 	for i := uint32(0); i < uint32(n); i++ {
 		binary.BigEndian.PutUint32(n1, i)
 		f.Add(n1)
@@ -246,12 +253,10 @@ func (f *BloomFilter) EstimateFalsePositiveRate(n uint) (fpRate float64) {
 	for i := uint32(0); i < rounds; i++ {
 		binary.BigEndian.PutUint32(n1, i+uint32(n)+1)
 		if f.Test(n1) {
-			//fmt.Printf("%v failed.\n", i+uint32(n)+1)
 			fp++
 		}
 	}
 	fpRate = float64(fp) / (float64(rounds))
-	f.ClearAll()
 	return
 }
 

--- a/bloom_test.go
+++ b/bloom_test.go
@@ -154,8 +154,7 @@ func TestString(t *testing.T) {
 
 func testEstimated(n uint, maxFp float64, t *testing.T) {
 	m, k := EstimateParameters(n, maxFp)
-	f := NewWithEstimates(n, maxFp)
-	fpRate := f.EstimateFalsePositiveRate(n)
+	fpRate := EstimateFalsePositiveRate(m, k, n)
 	if fpRate > 1.5*maxFp {
 		t.Errorf("False positive rate too high: n: %v; m: %v; k: %v; maxFp: %f; fpRate: %f, fpRate/maxFp: %f", n, m, k, maxFp, fpRate, fpRate/maxFp)
 	}
@@ -429,7 +428,7 @@ func BenchmarkEstimated(b *testing.B) {
 	for n := uint(100000); n <= 100000; n *= 10 {
 		for fp := 0.1; fp >= 0.0001; fp /= 10.0 {
 			f := NewWithEstimates(n, fp)
-			f.EstimateFalsePositiveRate(n)
+			EstimateFalsePositiveRate(f.m, f.k, n)
 		}
 	}
 }

--- a/murmur_test.go
+++ b/murmur_test.go
@@ -33,7 +33,7 @@ func TestHashBasic(t *testing.T) {
 
 func TestDocumentation(t *testing.T) {
 	filter := NewWithEstimates(10000, 0.01)
-	got := filter.EstimateFalsePositiveRate(10000)
+	got := EstimateFalsePositiveRate(filter.m, filter.k, 10000)
 	if got > 0.011 || got < 0.009 {
 		t.Errorf("Bad false positive rate %v", got)
 	}


### PR DESCRIPTION
The design of  EstimateFalsePositiveRate is ugly and unlikely to be used in production by anyone. This PR breaks it up and provides a new interface.

See https://github.com/bits-and-blooms/bloom/pull/80