### PR TITLE
This improves slightly the documentation.

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -225,7 +225,9 @@ func (f *BloomFilter) TestLocations(locs []uint64) bool {
 	return true
 }
 
-// TestAndAdd is the equivalent to calling Test(data) then Add(data).
+// TestAndAdd is equivalent to calling Test(data) then Add(data).
+// The filter is written to unconditionnally: even if the element is present,
+// the corresponding bits are still set. See also TestOrAdd.
 // Returns the result of Test.
 func (f *BloomFilter) TestAndAdd(data []byte) bool {
 	present := true
@@ -241,12 +243,15 @@ func (f *BloomFilter) TestAndAdd(data []byte) bool {
 }
 
 // TestAndAddString is the equivalent to calling Test(string) then Add(string).
+// The filter is written to unconditionnally: even if the string is present,
+// the corresponding bits are still set. See also TestOrAdd.
 // Returns the result of Test.
 func (f *BloomFilter) TestAndAddString(data string) bool {
 	return f.TestAndAdd([]byte(data))
 }
 
-// TestOrAdd is the equivalent to calling Test(data) then if not present Add(data).
+// TestOrAdd is equivalent to calling Test(data) then if not present Add(data).
+// If the element is already in the filter, then the filter is unchanged.
 // Returns the result of Test.
 func (f *BloomFilter) TestOrAdd(data []byte) bool {
 	present := true
@@ -262,6 +267,7 @@ func (f *BloomFilter) TestOrAdd(data []byte) bool {
 }
 
 // TestOrAddString is the equivalent to calling Test(string) then if not present Add(string).
+// If the string is already in the filter, then the filter is unchanged.
 // Returns the result of Test.
 func (f *BloomFilter) TestOrAddString(data string) bool {
 	return f.TestOrAdd([]byte(data))


### PR DESCRIPTION
The `TestAndAdd` and `TestOrAdd` methods differ in a small manner that might not always be clear to the user. This PR tries to improve the comments/documentation.

This relates to PR https://github.com/bits-and-blooms/bloom/pull/81 by @SimFG 

I am honestly not sure what `TestAndAdd` is good for given that we have `TestOrAdd`. It was added by @chkno in 2013...

https://github.com/bits-and-blooms/bloom/commit/7924c81d327f2e9b2bfef5376106c7064e4be7fe

Meanwhile `TestOrAdd` is a more recent addition (2021?) by @moredure ...

https://github.com/bits-and-blooms/bloom/commit/dd9e96df53ad3229c2693b8b0fa58ae1351749e3 

It might be time to do away with `TestAndAdd`.