### PR TITLE
Create simple example_test.go

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,20 @@
+package bloom_test
+
+import (
+	"fmt"
+	"github.com/bits-and-blooms/bloom/v3"
+)
+
+func Example() {
+	filter := bloom.NewWithEstimates(1000000, 0.01)
+	filter.Add([]byte("Love"))
+	fmt.Println(filter.Test([]byte("Love")))
+
+	var n uint = 1_000_000
+	fmt.Println(bloom.EstimateFalsePositiveRate(20*n, 5, n) > 0.001)
+
+	expectedFpRate := 0.01
+	m, k := bloom.EstimateParameters(n, expectedFpRate)
+	actualFpRate := bloom.EstimateFalsePositiveRate(m, k, n)
+	fmt.Printf("expectedFpRate=%v, actualFpRate=%v\n", expectedFpRate, actualFpRate)
+}


### PR DESCRIPTION
What are the changes?
- Create a file named as "example_test.go" for testable example.
- The example file has different package scope with name as "bloom_test"
- Reference: https://go.dev/blog/examples

What is it useful?
- it would be more convenient for developers to just interact with this package on https://pkg.go.dev/github.com/bits-and-blooms/bloom/v3

Sample:
![Screenshot 2023-01-20 at 15 59 26](https://user-images.githubusercontent.com/37653481/213648948-49212c15-6c5f-4555-8a8f-0934f099086c.png)

