### PR TITLE
Do not ceil `k` hash functions.

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -132,7 +132,7 @@ func (f *BloomFilter) location(h [4]uint64, i uint) uint {
 // used with permission.
 func EstimateParameters(n uint, p float64) (m uint, k uint) {
 	m = uint(math.Ceil(-1 * float64(n) * math.Log(p) / math.Pow(math.Log(2), 2)))
-	k = uint(math.Ceil(math.Log(2) * float64(m) / float64(n)))
+	k = uint(math.Log(2) * float64(m) / float64(n))
 	return
 }
 


### PR DESCRIPTION
Flooring `k` instead of ceiling has meaningful effect on performance since: (1) `k` is smaller by 1 which translate for fewer calls. (2) the fillrate of the filter is lower so non existing elements will get a negative bit faster.

For a filter with 1% false-positive-probability we can expect a 10-15% performance gain.