### PR TITLE
fix: incorrect error message in BloomFilter.Merge

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -175,7 +175,7 @@ func (f *BloomFilter) Merge(g *BloomFilter) error {
 	}
 
 	if f.k != g.k {
-		return fmt.Errorf("k's don't match: %d != %d", f.m, g.m)
+		return fmt.Errorf("k's don't match: %d != %d", f.k, g.k)
 	}
 
 	f.b.InPlaceUnion(g.b)


### PR DESCRIPTION
Correct variable references in k-value mismatch error message to show actual k parameters (f.k/g.k) instead of m values. Improves debugging clarity when merging filters with different hash function counts.