### PR TITLE
fix: handle saturated bitset in ApproximatedSize

### DIFF
--- a/bloom.go
+++ b/bloom.go
@@ -314,7 +314,14 @@ func (f *BloomFilter) ApproximatedSize() uint32 {
 	x := float64(f.b.Count())
 	m := float64(f.Cap())
 	k := float64(f.K())
+	if x >= m {
+		// Saturated filter: return max value since the estimate is infinite.
+		return math.MaxUint32
+	}
 	size := -1 * m / k * math.Log(1-x/m) / math.Log(math.E)
+	if math.IsInf(size, 1) || math.IsNaN(size) || size > float64(math.MaxUint32) {
+		return math.MaxUint32
+	}
 	return uint32(math.Floor(size + 0.5)) // round
 }
 


### PR DESCRIPTION
Fixes #104

## Problem

`ApproximatedSize()` produces `+Inf` when the bitset is fully saturated (`x == m`), because `log(1 - x/m) = log(0) = -Inf`. Converting `+Inf` to `uint32` is undefined behavior in Go:

- **amd64**: returns `0`
- **arm64**: returns `4294967295` (MaxUint32)

## Fix

Guard against saturation and overflow:
1. Return `MaxUint32` when all bits are set (`x >= m`)
2. Return `MaxUint32` when the computed size is `+Inf`, `NaN`, or exceeds `MaxUint32`

This provides consistent cross-platform behavior.

All existing tests pass.